### PR TITLE
Allow configurable report output directory.

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -77,6 +77,8 @@ var setup = {
 };
 
 module.exports = {
+  name: 'buster-istanbul',
+
   create: function(options) {
     var instance = Object.create(this);
     instance.options = options;
@@ -85,8 +87,9 @@ module.exports = {
 
   configure: function(group) {
     setup[group.environment](group);
+    var self = this;
     process.on("exit", function() {
-      coverage.writeReports();
+      coverage.writeReports(self.options.outputDirectory);
     });
   },
 


### PR DESCRIPTION
This change is to allow report output directory to be configurable from buster.js file:
{
  "extensions": [ require("buster-istanbul") ],
  "buster-istanbul": { "outputDirectory": "foo/bar" }
}

When outputDirectory is not configured, then it falls back to default current directory.
