### PR TITLE
Add cobertura reporter as a default for use with Jenkins

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -156,6 +156,7 @@ function writeReportsInternal(dir, collector) {
     dir = dir || process.cwd();
     var reports = [
         Report.create('lcov', { dir: dir }),
+        Report.create('cobertura', { dir: dir }),
         Report.create('text'),
         Report.create('text-summary')
     ];


### PR DESCRIPTION
I want to integrate the coverage stats with some Jenkins jobs. To do this I need to output the coverage stats in cobertura format. Instanbul supports this format, however this module did not have a mechanism for specifying new reporters.

For the moment I have just added a new reporter line into #writeReportsInternal, not sure if this is the best way or you would want a better way of specifying reporters.
