### PR TITLE
Allow the developer to opt out of instrumentation - enable browserify + buster + istanbul

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -21,8 +21,9 @@ function merge(paths) {
 }
 
 var setup = {
-  node: function(group) {
+  node: function(group, instrument) {
     coverage.hookRequire();
+    if (instrument === false) return;
     group.sources.forEach(function(pattern) {
       glob.glob(pattern).forEach(function(fPath) {
         coverage.addInstrumentCandidate(fPath);
@@ -44,6 +45,7 @@ var setup = {
     });
 
     group.on('load:sources', function(rs){
+      if (instrument === false) return;
       rs.addProcessor(function(resource, content){
         return coverage.instrumentCode(content, resource['path'].replace(/\//, ''));
       });
@@ -86,7 +88,7 @@ module.exports = {
   },
 
   configure: function(group) {
-    setup[group.environment](group);
+    setup[group.environment](group, this.options.instrument);
     var self = this;
     process.on("exit", function() {
       coverage.writeReports(self.options.outputDirectory);


### PR DESCRIPTION
Hi @kates,

Firstly thanks for an amazing library.  [You can see how far I got](https://github.com/matthew-andrews/buster-coverage-istanbul) implementing my own before I realised your's did _almost_ everything I wanted, better.

Basically the background of this is for our projects we use [browserify](https://github.com/substack/node-browserify) and buster.js.

The way @gotwarlost, author of Istanbul, [suggests to use browserify with istanbul](https://github.com/gotwarlost/istanbul/issues/59) is to first instrument the individual javascript modules, then compile, then run the unit tests.  This works beautifully - until you want to plug that into buster.js..

I tried to implement this bit myself ([with some success](https://github.com/matthew-andrews/buster-coverage-istanbul)) but afterwards realised that actually I'd made something that did almost the same things as this library - so it would probably be better to try to merge the two together. 

It turns out merging them only required one tiny change - adding the option for the developer to opt out of the way your library automatically instruments the javascript files so that the instrumenting and compiling happen in steps before running the buster tests (I used grunt to run the tasks and [grunt-istanbul](https://github.com/taichi/grunt-istanbul) to instrument (just) the files that I was interested in).

(Also we want to be able to put other types of code in the `sources` section of our buster.js config without having those instrumented (eg mocks, sample data, etc). - For this reason I've added the `instrument: false` option for node as well as browsers)

I've tried to keep my changes to a minimum and would be more than happy to tweak them to adhere to your preferred coding styles - just let me know what you would like to change.

Thanks again,

Matt
