### PR TITLE
Don't know how we managed to miss this...

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -60,7 +60,7 @@ var setup = {
     });
   },
 
-  browser: function(group) {
+  browser: function(group, instrument) {
     var options = group.config.options;
 
     global['__coverage__'] = global['__coverage__'] || {};


### PR DESCRIPTION
Currently an error get thrown when using buster browser testing... instrument is undefined because it's not listed as an argument in the setup method.

Do not know how we both managed to miss this! 

This is the error:

```
ReferenceError: load:sources listener threw error: instrument is not defined
    at Object.<anonymous> (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster-istanbul/lib/buster-istanbul.js:77:11)
    at notifyListener (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/buster-core/lib/buster-event-emitter.js:37:31)
    at Object.emit (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/buster-core/lib/buster-event-emitter.js:101:17)
    at /Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/buster-test-cli/node_modules/buster-cli/node_modules/buster-configuration/lib/group.js:126:15
    at Object.p.then (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/when/when.js:71:31)
    at /Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/when/when.js:154:13
    at complete (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/when/when.js:257:5)
    at Object.resolve (/Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/when/when.js:189:4)
    at /Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/buster-test-cli/node_modules/buster-cli/node_modules/buster-configuration/node_modules/ramp-resources/lib/resource-set.js:336:28
    at /Users/matthew/Documents/sandboxes/superstore/node_modules/buster/node_modules/buster-test-cli/node_modules/buster-cli/node_modules/buster-configuration/node_modules/ramp-resources/lib/resource-set.js:96:13
```
