### PR TITLE
allow filtering for paths

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -53,7 +53,11 @@ var setup = {
   node: function(group, instrument) {
     coverage.hookRequire();
     if (instrument === false) return;
+    var processPath = process.cwd().split('/').pop()+'/';
     group.sources.forEach(function(pattern) {
+      if (pattern.indexOf(processPath) === 0) {
+        pattern = pattern.replace(processPath, '');
+      }
       glob.sync(pattern).forEach(function(fPath) {
         coverage.addInstrumentCandidate(fPath);
       });


### PR DESCRIPTION
for our tests we need an extended root path,

projectA
  - public
    - foo.js ( requires code from projectB.shared.js)
  - test
     - buster.js (rootPath = '../../', sources: 'projectA/public/*.js' )

projectB
  - public
     - shared.js

in order to run buster the rootPath must be the directory where both projects reside, but that breaks coverage, so i must be able to strip out the "projectA" part of the test sources.

this is possible with this commit, hopefully not breaking existing code
please review and merge, or adjust