### PR TITLE
Add exclusion feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ module.exports.tests = {
     ],
     "buster-istanbul": {
       outputDirectory: "coverage",
-      format: "lcov"
+      format: "lcov",
+      excludes: ["**/*.json"]
     },
     extensions: [
         require('buster-istanbul')
@@ -65,6 +66,10 @@ Valid values is `true` or `false`. Defaults to `false`.
 
 `instrument` is a flag to turn off instrumentation of your source file.
 You will need to handle this yourself. Defaults to `true`.
+
+`excludes` is an array of glob paths that will be excluded from instrumentation.
+This can be helpful if your sources include non-js files that needed to be excluded, such as .html or .json files.
+Consult [node-glob](https://github.com/isaacs/node-glob) for more information on globs.
 
 Write your buster test as usual.
 

--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -10,7 +10,8 @@ var buster = require('buster-core'),
   coverage = require('./coverage'),
   glob = require('glob'),
   path = require('path'),
-  istanbul = require('istanbul');
+  istanbul = require('istanbul'),
+  minimatch = require('minimatch');
 
 function merge(paths) {
   return paths.reduce(function(a, c){
@@ -49,18 +50,34 @@ function writeReports(dir, formats, silent) {
   }
 }
 
+// reusable method to check for exclusions
+var isExcluded = function(path, excludes){
+  var excluded = false;
+
+  if (path && excludes && excludes.length) {
+    excluded = excludes.some(function(exclude){
+      return minimatch(path, exclude);
+    });
+  }
+
+  return excluded;
+}
+
 var setup = {
-  node: function(group, instrument) {
+  node: function(group, instrument, excludes) {
     coverage.hookRequire();
     if (instrument === false) return;
     group.sources.forEach(function(pattern) {
       glob.sync(pattern).forEach(function(fPath) {
-        coverage.addInstrumentCandidate(fPath);
+        var excluded = isExcluded(fPath, excludes);
+        if (!excluded) {
+          coverage.addInstrumentCandidate(fPath);
+        }
       });
     });
   },
 
-  browser: function(group, instrument) {
+  browser: function(group, instrument, excludes) {
     var options = group.config.options;
 
     global['__coverage__'] = global['__coverage__'] || {};
@@ -76,7 +93,10 @@ var setup = {
     group.on('load:sources', function(rs){
       if (instrument === false) return;
       rs.addProcessor(function(resource, content){
-        return coverage.instrumentCode(content, resource['path'].replace(/\//, ''));
+        var path = resource.path.replace(/\//, '');
+        var excluded = isExcluded(path, excludes);
+
+        return excluded ? content : coverage.instrumentCode(content, path);
       });
     });
 
@@ -118,7 +138,7 @@ module.exports = {
 
   configure: function(group) {
     var opts = this.options;
-    setup[group.environment](group, opts.instrument);
+    setup[group.environment](group, opts.instrument, opts.excludes);
     process.on("exit", function() {
       writeReports(opts.outputDirectory, opts.format || opts.formats, !!opts.silent);
     });

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "dependencies": {
     "buster-core": "*",
+    "glob": "*",
     "istanbul": "*",
-    "glob": "*"
+    "minimatch": "^2.0.1"
   },
   "devDependencies": {
     "grunt": "~0.3.17"


### PR DESCRIPTION
Fix #10. `exclude` is an option of the extension config.

Use:

```javascript
excludes: [
  // exclude json files from being instrumented
  "**/*.json",
  // exclude html files from being instrumented
  "**/*.html",
  // exclude gif, jpg, or png files from being instrumented
  "**/*.+(gif|jpg|png)",
  // exclude whole directories
  "some/folder/**/*"
  ]
```