### PR TITLE
Correct source paths for instrumentation

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -98,7 +98,7 @@ var setup = {
       if (instrument === false) return;
       rs.addProcessor(function(resource, content){
         // properly join the path, using the rootPath
-        var resourcePath = path.join(rootPath, resource.path);
+        var resourcePath = path.join(rootPath, resource.path.replace(/\//, ''));
         var excluded = isExcluded(resourcePath, excludes);
 
         return excluded ? content : coverage.instrumentCode(content, resourcePath);

--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -93,10 +93,12 @@ var setup = {
     group.on('load:sources', function(rs){
       if (instrument === false) return;
       rs.addProcessor(function(resource, content){
-        var path = resource.path.replace(/\//, '');
-        var excluded = isExcluded(path, excludes);
+        // properly resolve the path, using the rootPath
+        // otherwise resolve defaults to the current working directory
+        var resourcePath = path.resolve(rootPath, resource.path.replace(/\//, ''));
+        var excluded = isExcluded(resourcePath, excludes);
 
-        return excluded ? content : coverage.instrumentCode(content, path);
+        return excluded ? content : coverage.instrumentCode(content, resourcePath);
       });
     });
 

--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -70,11 +70,11 @@ var setup = {
     group.on('load:sources', function(rs){
       var rootPath = rs.rootPath
       rs.forEach(function(resource){
-        var resourcePath = path.join(rootPath, resource.path);
+        var resourcePath = resource.path.replace(/\//, '');
         var excluded = isExcluded(resourcePath, excludes);
 
         if (!excluded) {
-          coverage.addInstrumentCandidate(resourcePath);
+          coverage.addInstrumentCandidate(path.join(rootPath, resourcePath));
         }
       });
     });
@@ -98,10 +98,10 @@ var setup = {
       if (instrument === false) return;
       rs.addProcessor(function(resource, content){
         // properly join the path, using the rootPath
-        var resourcePath = path.join(rootPath, resource.path.replace(/\//, ''));
+        var resourcePath = resource.path.replace(/\//, '');
         var excluded = isExcluded(resourcePath, excludes);
 
-        return excluded ? content : coverage.instrumentCode(content, resourcePath);
+        return excluded ? content : coverage.instrumentCode(content, path.join(rootPath, resourcePath));
       });
     });
 

--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -67,11 +67,14 @@ var setup = {
   node: function(group, instrument, excludes) {
     coverage.hookRequire();
     if (instrument === false) return;
-    group.sources.forEach(function(pattern) {
-      glob.sync(pattern).forEach(function(fPath) {
-        var excluded = isExcluded(fPath, excludes);
+    group.on('load:sources', function(rs){
+      var rootPath = rs.rootPath
+      rs.forEach(function(resource){
+        var resourcePath = path.join(rootPath, resource.path);
+        var excluded = isExcluded(resourcePath, excludes);
+
         if (!excluded) {
-          coverage.addInstrumentCandidate(fPath);
+          coverage.addInstrumentCandidate(resourcePath);
         }
       });
     });
@@ -91,11 +94,11 @@ var setup = {
     });
 
     group.on('load:sources', function(rs){
+      var rootPath = rs.rootPath;
       if (instrument === false) return;
       rs.addProcessor(function(resource, content){
-        // properly resolve the path, using the rootPath
-        // otherwise resolve defaults to the current working directory
-        var resourcePath = path.resolve(rootPath, resource.path.replace(/\//, ''));
+        // properly join the path, using the rootPath
+        var resourcePath = path.join(rootPath, resource.path);
         var excluded = isExcluded(resourcePath, excludes);
 
         return excluded ? content : coverage.instrumentCode(content, resourcePath);


### PR DESCRIPTION
`coverage.instrumentCode` executes `path.resolve(filename)` which uses the current working directory as the base. This can incorrectly identify the file path and cause `istanbul` to throw an error when the file can't be found.

With a file structure like the following:
```bash
#root directory
/a
/a/index.js
/a/some/index.js

#tests
/a/test

#node modules with buster installed locally
/a/node_modules/buster

#buster config where rootPath is ../
/a/test/buster.js

# command that would cause errors
# file path /a/test/index.js
# file path /a/test/some/index.js
/a/test $ ../node_modules/.bin/buster-test

# command that would NOT cause errors
# file path /a/index.js
# file path /a/some/index.js
/a $ ./node_modules.bin/buster-test
```

To fix this, the `rootPath` is joined with the `resource.path`.