### PR TITLE
cleanup upon suite:end

### DIFF
--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -121,7 +121,7 @@ var setup = {
           path: "/" + options.amd.require
         }).then(function(){
           rs.loadPath.prepend('/' + options.amd.require);
-        }); 
+        });
       }
     });
   }
@@ -147,6 +147,9 @@ module.exports = {
   testRun: function(testRunner, messageClient) {
     testRunner.on("istanbul:report", function(result){
       coverage.addCoverage(result.data || {});
+    });
+    testRunner.on("suite:end", function () {
+      coverage.unhookRequire();
     });
   }
 };


### PR DESCRIPTION
Needed so that the next test group in `buster.js` has a clean slate to `hookRequire` again (otherwise we get an infinite loop somewhere and one of requires ends up with "Maximum stack size exceeded" with latest `istanbul`)