### PR TITLE
Enable additional instrumentation sources to be defined in "buster-istanbul" config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ You will need to handle this yourself. Defaults to `true`.
 This can be helpful if your sources include non-js files that needed to be excluded, such as .html or .json files.
 Consult [node-glob](https://github.com/isaacs/node-glob) for more information on globs.
 
+`sources` is an array of glob paths that will be instrumented in addition to paths supplied in global sources. This
+allows paths to be instrumented, but not automatically loaded. Note: This only has effect in a node environment
+
 Write your buster test as usual.
 
 Example project: [buster-istanbul-demo](https://github.com/kates/buster-istanbul-demo)

--- a/lib/buster-istanbul.js
+++ b/lib/buster-istanbul.js
@@ -68,15 +68,32 @@ var setup = {
     coverage.hookRequire();
     if (instrument === false) return;
     group.on('load:sources', function(rs){
-      var rootPath = rs.rootPath
-      rs.forEach(function(resource){
-        var resourcePath = resource.path.replace(/\//, '');
-        var excluded = isExcluded(resourcePath, excludes);
+      var rootPath = rs.rootPath,
+        additional = group.config['buster-istanbul'].sources;
 
+      if (Array.isArray(additional)) {
+          additional.forEach(processAdditional);
+      }
+      rs.forEach(processResource);
+      function processAdditional(a) {
+        glob(a, function (er, files) {
+          if (er) {
+            throw er;
+          } else {
+            files.forEach(processResource);
+          }
+        });
+      }
+      function processResource(resource) {
+        if (typeof resource === 'object') {
+          resource = resource.path;
+        }
+        var resourcePath = resource.replace(/^\//, '');
+        var excluded = isExcluded(resourcePath, excludes);
         if (!excluded) {
           coverage.addInstrumentCandidate(path.join(rootPath, resourcePath));
         }
-      });
+      }
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buster-istanbul",
   "description": "buster extension for istanbul code coverage.",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "homepage": "https://github.com/major-mann/buster-istanbul",
   "author": {
     "name": "kates",

--- a/package.json
+++ b/package.json
@@ -2,22 +2,22 @@
   "name": "buster-istanbul",
   "description": "buster extension for istanbul code coverage.",
   "version": "0.1.16",
-  "homepage": "https://github.com/major-mann/buster-istanbul",
+  "homepage": "https://github.com/englishtown/buster-istanbul",
   "author": {
     "name": "kates",
     "email": "katesgasis@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:major-mann/buster-istanbul.git"
+    "url": "git://github.com/englishtown/buster-istanbul.git"
   },
   "bugs": {
-    "url": "https://github.com/major-mann/buster-istanbul/issues"
+    "url": "https://github.com/englishtown/buster-istanbul/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/major-mann/buster-istanbul/blob/master/LICENSE-MIT"
+      "url": "https://github.com/englishtown/buster-istanbul/blob/master/LICENSE-MIT"
     }
   ],
   "main": "lib/buster-istanbul",

--- a/package.json
+++ b/package.json
@@ -2,22 +2,22 @@
   "name": "buster-istanbul",
   "description": "buster extension for istanbul code coverage.",
   "version": "0.1.15",
-  "homepage": "https://github.com/englishtown/buster-istanbul",
+  "homepage": "https://github.com/major-mann/buster-istanbul",
   "author": {
     "name": "kates",
     "email": "katesgasis@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/englishtown/buster-istanbul.git"
+    "url": "git@github.com:major-mann/buster-istanbul.git"
   },
   "bugs": {
-    "url": "https://github.com/englishtown/buster-istanbul/issues"
+    "url": "https://github.com/major-mann/buster-istanbul/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/englishtown/buster-istanbul/blob/master/LICENSE-MIT"
+      "url": "https://github.com/major-mann/buster-istanbul/blob/master/LICENSE-MIT"
     }
   ],
   "main": "lib/buster-istanbul",


### PR DESCRIPTION
When running in a node environment, adding the sources to the global array can be undesirable as buster automatically calls require on the sources and runs the source code.

This change adds the ability to put a sources array into the local configuration which will be globbed and then added to the collection of files to instrument.

This allows files to be instrumented without also being executed.
